### PR TITLE
Add Jack

### DIFF
--- a/io.github.celluloid_player.Celluloid.json
+++ b/io.github.celluloid_player.Celluloid.json
@@ -9,6 +9,7 @@
       "--socket=fallback-x11",
       "--socket=wayland",
       "--device=all",
+      "--filesystem=xdg-run/pipewire-0:ro",
       "--share=network",
       "--socket=pulseaudio",
       "--filesystem=xdg-pictures",
@@ -60,6 +61,23 @@
             }
           ],
           "modules": [
+            {
+              "name": "jack2",
+              "buildsystem": "simple",
+              "build-commands": [
+                "python3 waf configure --prefix=/app",
+                "python3 waf build",
+                "python3 waf install"
+              ],
+              "cleanup": [ "*" ],
+              "sources": [
+                {
+                  "type": "archive",
+                  "url": "https://github.com/jackaudio/jack2/archive/v1.9.16.tar.gz",
+                  "sha256": "e176d04de94dcaa3f9d32ca1825091e1b938783a78c84e7466abd06af7637d37"
+                }
+              ]
+            },
             {
               "name": "luajit",
               "no-autogen": true,


### PR DESCRIPTION
The turns on jack support via PipeWire. Can be tested by loading and `mpv.conf` with the following content

```
ao=jack
audio-channels=stereo
```
and confirmed via a Jack control app / patch bay, e.g. `njcontrol`. 

I wasn't sure if hardcoding the socket filename is the right approach but as this was also done with [org.chromium.Chromium](https://github.com/flathub/org.chromium.Chromium/blob/master/org.chromium.Chromium.yaml) so I guess it's o.k.