### PR TITLE
enable mpv player

### DIFF
--- a/io.github.celluloid_player.Celluloid.json
+++ b/io.github.celluloid_player.Celluloid.json
@@ -39,10 +39,10 @@
       "modules": [
         {
           "name": "libmpv",
-          "cleanup": [ "/include", "/lib/pkgconfig", "/share/man" ],
+          "cleanup": [ "/include", "/lib/pkgconfig", "/share/applications", "/share/bash-completion", "/share/doc", "/share/icons", "/share/man", "/share/zsh" ],
           "buildsystem": "simple",
           "build-commands": [
-            "python3 waf configure --prefix=/app --enable-libmpv-shared --disable-cplayer --disable-build-date --disable-alsa",
+            "python3 waf configure --prefix=/app --enable-libmpv-shared --disable-build-date --disable-alsa",
             "python3 waf build",
             "python3 waf install"
           ],


### PR DESCRIPTION
Enabling the CLI player just add 2MB to the package, and it can be very useful to some users like me who would love to get the CLI player from Flathub.  
The desktop file was removed, not to mention not being exported, as this should be left for a dedicated MPV package.

In the future, maybe the right solution would be to have an MPV base package that can be reused, but for the time being, it would be nice to see this merged.