### PR TITLE
add mujs javascript backend

### DIFF
--- a/io.github.celluloid_player.Celluloid.json
+++ b/io.github.celluloid_player.Celluloid.json
@@ -151,6 +151,30 @@
                   "sha256": "3fc79408ae1d84b406922fa9319ce005631c95ca0f34b205fad867e8b30e45b1"
                 }
               ]
+            },
+            {
+              "name": "mujs",
+              "cleanup": [ "/bin", "/include", "/lib/pkgconfig", "/lib/libmujs.a" ],
+              "no-autogen": true,
+              "make-args": [
+                "release",
+                "shared"
+              ],
+              "make-install-args": [
+                "prefix=/app",
+                "install-shared"
+              ],
+              "sources": [
+                {
+                  "type": "git",
+                  "url": "https://github.com/ccxvii/mujs",
+                  "tag": "1.0.9"
+                },
+                {
+                  "type": "patch",
+                  "path": "mujs-build-flags.patch"
+                }
+              ]
             }
           ]
         }

--- a/mujs-build-flags.patch
+++ b/mujs-build-flags.patch
@@ -1,0 +1,46 @@
+diff --git a/Makefile b/Makefile
+index eacdc49..7b24457 100644
+--- a/Makefile
++++ b/Makefile
+@@ -15,7 +15,7 @@ endif
+ 
+ # Compiler flags for various configurations:
+ 
+-CFLAGS := -std=c99 -pedantic -Wall -Wextra -Wno-unused-parameter
++CFLAGS += -std=c99 -pedantic -Wall -Wextra -Wno-unused-parameter
+ 
+ ifeq "$(CC)" "clang"
+   CFLAGS += -Wunreachable-code
+@@ -30,9 +30,6 @@ ifeq "$(build)" "debug"
+ else ifeq "$(build)" "sanitize"
+   CFLAGS += -pipe -g -fsanitize=address -fno-omit-frame-pointer
+   LDFLAGS += -fsanitize=address
+-else
+-  CFLAGS += -Os
+-  LDFLAGS += -Wl,-s
+ endif
+ 
+ ifeq "$(HAVE_READLINE)" "yes"
+@@ -67,11 +64,11 @@ jsdump.c: astnames.h opnames.h
+ 
+ $(OUT)/%.o: %.c $(HDRS)
+ 	@ mkdir -p $(dir $@)
+-	$(CC) $(CFLAGS) -o $@ -c $<
++	$(CC) $(CFLAGS) $(CPPFLAGS) -o $@ -c $<
+ 
+ $(OUT)/libmujs.o: one.c $(HDRS)
+ 	@ mkdir -p $(dir $@)
+-	$(CC) $(CFLAGS) -o $@ -c $<
++	$(CC) $(CFLAGS) $(CPPFLAGS) -o $@ -c $<
+ 
+ $(OUT)/libmujs.a: $(OUT)/libmujs.o
+ 	@ mkdir -p $(dir $@)
+@@ -79,7 +76,7 @@ $(OUT)/libmujs.a: $(OUT)/libmujs.o
+ 
+ $(OUT)/libmujs.so: one.c $(HDRS)
+ 	@ mkdir -p $(dir $@)
+-	$(CC) $(CFLAGS) -fPIC -shared -o $@ $< -lm
++	$(CC) $(CFLAGS) $(CPPFLAGS) -fPIC -shared $(LDFLAGS) -o $@ $< -lm
+ 
+ $(OUT)/mujs: $(OUT)/libmujs.o $(OUT)/main.o
+ 	@ mkdir -p $(dir $@)


### PR DESCRIPTION
This add mujs shared library to enable the javascript extensions
backend.
Note that I use the git source to avoid breaking the version detection
in the makefile and ending up with a wrong value for Version in the
pkgconfig file.
closes #15.

Need to be tested.