### PR TITLE
Update org.gnome.Platform to 41

### DIFF
--- a/io.github.celluloid_player.Celluloid.json
+++ b/io.github.celluloid_player.Celluloid.json
@@ -12,6 +12,7 @@
         "--share=network",
         "--socket=pulseaudio",
         "--filesystem=xdg-pictures",
+        "--filesystem=xdg-run/gvfs", "--filesystem=xdg-run/gvfsd",
         "--talk-name=org.gtk.vfs",
         "--talk-name=org.gtk.vfs.*",
         "--talk-name=org.gnome.SettingsDaemon.MediaKeys",

--- a/io.github.celluloid_player.Celluloid.json
+++ b/io.github.celluloid_player.Celluloid.json
@@ -1,7 +1,7 @@
 {
     "app-id": "io.github.celluloid_player.Celluloid",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "40",
+    "runtime-version": "41",
     "sdk": "org.gnome.Sdk",
     "command": "celluloid",
     "finish-args": [


### PR DESCRIPTION
Also add `xdg-run/gvfs` and `xdg-run/gvfsd` filesystem permission which requires gvfs >= 1.48. See: https://github.com/flathub/flathub/issues/2180.

Tested this build and LGTM so far.