### PR TITLE
Add read-only access to xdg-config/mpv

### DIFF
--- a/io.github.celluloid_player.Celluloid.yaml
+++ b/io.github.celluloid_player.Celluloid.yaml
@@ -14,6 +14,7 @@ finish-args:
   - --filesystem=xdg-pictures
   - --filesystem=xdg-run/gvfs
   - --filesystem=xdg-run/gvfsd
+  - --filesystem=xdg-config/mpv:ro
   - --talk-name=org.gtk.vfs.*
   - --talk-name=org.gnome.SettingsDaemon.MediaKeys
   - --env=LC_NUMERIC=C


### PR DESCRIPTION
This adds read-only access to `xdg-config/mpv` as it relates to the settings in "Preferences > Config Files" which directly reference mpv.