### PR TITLE
Update modules

### DIFF
--- a/io.github.celluloid_player.Celluloid.yaml
+++ b/io.github.celluloid_player.Celluloid.yaml
@@ -60,8 +60,8 @@ modules:
           - python3 waf install
         sources:
           - type: archive
-            url: https://github.com/mpv-player/mpv/archive/v0.35.1.tar.gz
-            sha256: 41df981b7b84e33a2ef4478aaf81d6f4f5c8b9cd2c0d337ac142fc20b387d1a9
+            url: https://github.com/mpv-player/mpv/archive/v0.36.0.tar.gz
+            sha256: 29abc44f8ebee013bb2f9fe14d80b30db19b534c679056e4851ceadf5a5e8bf6
             x-checker-data:
               type: anitya
               project-id: 5348
@@ -69,8 +69,8 @@ modules:
               url-template: https://github.com/mpv-player/mpv/archive/v$version.tar.gz
               is-important: true
           - type: file
-            url: https://waf.io/waf-2.0.25
-            sha256: 21199cd220ccf60434133e1fd2ab8c8e5217c3799199c82722543970dc8e38d5
+            url: https://waf.io/waf-2.0.26
+            sha256: dcec3e179f9c33a66544f1b3d7d91f20f6373530510fa6a858cddb6bfdcde14b
             dest-filename: waf
             x-checker-data:
               type: anitya
@@ -247,8 +247,8 @@ modules:
               - /lib/ladspa
             sources:
               - type: archive
-                url: https://breakfastquay.com/files/releases/rubberband-3.1.2.tar.bz2
-                sha256: dda7e257b14c59a1f59c5ccc4d6f19412039f77834275955aa0ff511779b98d2
+                url: https://breakfastquay.com/files/releases/rubberband-3.3.0.tar.bz2
+                sha256: d9ef89e2b8ef9f85b13ac3c2faec30e20acf2c9f3a9c8c45ce637f2bc95e576c
                 x-checker-data:
                   type: anitya
                   project-id: 4222
@@ -285,11 +285,11 @@ modules:
             sources:
               - type: git
                 url: https://github.com/haasn/libplacebo.git
-                commit: 8ae0648b459d8215bde7772501d5cba17e28bf53
+                commit: 06b51c6c1bc8be6153823929496eed255dd76e69
                 x-checker-data:
                   type: git
                   tag-pattern: ^v([\d.]+)$
-                tag: v5.264.0
+                tag: v6.292.1
             modules:
 
               - name: glslang
@@ -316,8 +316,8 @@ modules:
     sources:
       - type: git
         url: https://github.com/yt-dlp/yt-dlp.git
-        tag: 2023.03.04
-        commit: 8729e7b57c0d6e6350a76f82436e05d7b9891188
+        tag: 2023.07.06
+        commit: cc0619f62d6da52689797483e96b29290b0c0873
         x-checker-data:
           type: git
           tag-pattern: ^([\d.]+)$


### PR DESCRIPTION
The Flathub build was broken by `waf` and `rubberband` being outdated.
See: https://buildbot.flathub.org/#/builders/33/builds/7386